### PR TITLE
Improve error message for "URL unobtainable"

### DIFF
--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -305,7 +305,7 @@ def link_checker(context, data):
                 if res.status_code in HTTP_ERROR_CODES:
                     error_message = HTTP_ERROR_CODES[res.status_code]
                 else:
-                    error_message = "URL unobtainable"
+                    error_message = "URL unobtainable: HTTP %s on %r" % (res.status_code, url)
                 raise LinkCheckerError(error_message)
     return json.dumps(headers)
 


### PR DESCRIPTION
"URL unobtainable" is a rather uninformative message. The message would now, be, e.g.:

```
URL unobtainable: HTTP 404 on 'http://4m58.localtunnel.com//en/storage/f/2012-08-19T154553/dons_aux_partis_politiques_du_quebec.csv'
```
