### PR TITLE
Check if the response returned a correct status code

### DIFF
--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -152,6 +152,9 @@ def download(context, resource, url_timeout=30,
     except Exception, e:
         raise DownloadError('Error with the download: %s' % e)
 
+    if not res.ok:
+        raise DownloadError('Download failed with status code: %s' % res.status_code)
+
     length, hash, saved_file = _save_resource(resource, res, max_content_length)
 
     # check if resource size changed


### PR DESCRIPTION
The current implementation of `download` first performs an HEAD requests and then if everything went fine it gets the file. However it could happen that at the second request (GET) the status code is different from the first request (HEAD), so it's better to check it again.
