### PR TITLE
Add a User-Agent header to help prevent requests being blocked

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,14 +82,18 @@ Configuration
         to.
         MAX_CONTENT_LENGTH: the maximum size (in bytes) of files to archive.
         DATA_FORMATS: the data formats that are archived.
+        USER_AGENT_STRING: the `User-Agent` header used when the archiver makes requests
 
-   Alternatively, if you are running CKAN with this patch:
-   https://github.com/datagovuk/ckan/commit/83dcaf3d875d622ee0cd7f3c1f65ec27a970cd10
-   then you can instead add the settings to the CKAN config file as normal:
+    Alternatively, if you are running CKAN with this patch:
+    https://github.com/datagovuk/ckan/commit/83dcaf3d875d622ee0cd7f3c1f65ec27a970cd10
+    then you can instead add the settings to the CKAN config file as normal:
 
-    * ckanext-archiver.archive_dir
-    * ckanext-archiver.max_content_length
-    * ckanext-archiver.data_formats  (space separated)
+    ::
+
+        ckanext-archiver.archive_dir
+        ckanext-archiver.max_content_length
+        ckanext-archiver.data_formats  (space separated)
+        ckanext.archiver.user_agent_string
 
 
 Using Archiver

--- a/ckanext/archiver/default_settings.py
+++ b/ckanext/archiver/default_settings.py
@@ -10,7 +10,7 @@ MAX_CONTENT_LENGTH = int(config.get('ckanext-archiver.max_content_length', 50000
 
 # Only files with these mime-types or extensions will be archived.
 # To archive all files, set DATA_FORMATS = 'all'
-DEFAULT_DATA_FORMATS = [ 
+DEFAULT_DATA_FORMATS = [
     'csv',
     'text/csv',
     'txt',
@@ -22,7 +22,7 @@ DEFAULT_DATA_FORMATS = [
     'xml',
     'xls',
     'application/ms-excel',
-    'application/vnd.ms-excel',    
+    'application/vnd.ms-excel',
     'application/xls',
     'text/xml',
     'tar',
@@ -35,3 +35,5 @@ DEFAULT_DATA_FORMATS = [
     'application/octet-stream'
 ]
 DATA_FORMATS = config.get['ckanext-archiver.data_formats'].split() if 'ckan-archiver.data_formats' in config else DEFAULT_DATA_FORMATS
+
+USER_AGENT_STRING = config.get('ckanext.archiver.user_agent_string', None)


### PR DESCRIPTION
Some services are blocking requests made by ckanext-archiver as 403 Forbidden e.g. by mod_security. It can help to allow the archiver to be identified by a `User-Agent` request header. 