### PR TITLE
Add option to switch off HTTPS verifying

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -247,6 +247,7 @@ Config settings
       * ``ckanext-archiver.cache_url_root`` = URL where you will be publicly serving the cached files stored locally at ckanext-archiver.archive_dir.
       * ``ckanext-archiver.max_content_length`` = the maximum size (in bytes) of files to archive (default ``50000000`` =50MB)
       * ``ckanext-archiver.user_agent_string`` = identifies the archiver to servers it archives from
+      * ``ckanext-archiver.verify_https`` = true/false whether you want to verify https connections and therefore fail if it is specified in the URL but does not verify.
 
 4.  Nightly report generation
 

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -345,7 +345,9 @@ def download(context, resource, url_timeout=30,
     # May raise DownloadException
     method_func = {'GET': requests.get, 'POST': requests.post}[method]
     res = requests_wrapper(log, method_func, url, timeout=url_timeout,
-                           stream=True, headers=headers)
+                           stream=True, headers=headers,
+                           verify=verify_https(),
+                           )
     url_redirected_to = res.url if url != res.url else None
 
     if context.get('previous') and ('etag' in res.headers):
@@ -507,6 +509,11 @@ def notify_package(package, queue):
 def get_plugins_waiting_on_ipipe():
     return [observer.name for observer in
             p.PluginImplementations(archiver_interfaces.IPipe)]
+
+
+def verify_https():
+    from pylons import config
+    return toolkit.asbool(config.get('ckanext-archiver.verify_https', True))
 
 
 def _clean_content_type(ct):


### PR DESCRIPTION
For if openssl version is too old or you're not interested in checking certificates - just if the content is broken or not.

Relates to #24