### PR TITLE
Fix setup.py to match it's current paster template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,5 +107,5 @@ setup(
         ],
     },
 
-    namespace_packages=['ckanext', 'ckanext.archiver'],
+    namespace_packages=['ckanext'],
 )


### PR DESCRIPTION
Fixes plugin's setup.py namespace_packages to match the updated setup.py paster template. Fixes the issue mentioned in e.g. here: https://github.com/ckan/ckan/issues/2893