### PR TITLE
Migrate to new jobs system

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -297,6 +297,8 @@ However in production you'd run the priority and bulk queues separately, or else
 
 For production use, we recommend setting up Celery to run with supervisord. `apt-get install supervisor` and use `bin/celery-supervisor.conf` as a configuration template.
 
+If you are running CKAN 2.7 or higher, configure job workers instead http://docs.ckan.org/en/2.8/maintaining/background-tasks.html#using-supervisor
+
 An archival can be triggered by adding a dataset with a resource or updating a resource URL. Alternatively you can run::
 
     paster --plugin=ckanext-archiver archiver update [dataset] --queue=priority -c <path to CKAN config>

--- a/ckanext/archiver/lib.py
+++ b/ckanext/archiver/lib.py
@@ -5,7 +5,7 @@ import ckan.plugins as p
 from ckan.model.types import make_uuid
 from ckan.lib.celery_app import celery
 
-from ckanext.archiver.tasks import update_package
+from ckanext.archiver.tasks import update_package, update_resource
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ def create_archiver_resource_task(resource, queue):
     task_id = '%s/%s/%s' % (package.name, resource.id[:4], make_uuid()[:4])
     ckan_ini_filepath = os.path.abspath(config['__file__'])
 
-    compat_enqueue('archiver.update_resource', queue, [ckan_ini_filepath, resource.id])
+    compat_enqueue('archiver.update_resource', update_resource, queue, [ckan_ini_filepath, resource.id])
 
     log.debug('Archival of resource put into celery queue %s: %s/%s url=%r',
               queue, package.name, resource.id, resource.url)

--- a/ckanext/archiver/lib.py
+++ b/ckanext/archiver/lib.py
@@ -5,7 +5,24 @@ import ckan.plugins as p
 from ckan.model.types import make_uuid
 from ckan.lib.celery_app import celery
 
+from ckanext.archiver.tasks import update_package
+
 log = logging.getLogger(__name__)
+
+
+def compat_enqueue(name, fn, args=None):
+    u'''
+    Enqueue a background job using Celery or RQ.
+    '''
+    try:
+        # Try to use RQ
+        from ckan.plugins.toolkit import enqueue_job
+        enqueue_job(fn, args=args)
+    except ImportError:
+        # Fallback to Celery
+        import uuid
+        from ckan.lib.celery_app import celery
+        celery.send_task(name, args=args, task_id=str(uuid.uuid4()))
 
 
 def create_archiver_resource_task(resource, queue):
@@ -28,9 +45,12 @@ def create_archiver_package_task(package, queue):
     from pylons import config
     task_id = '%s/%s' % (package.name, make_uuid()[:4])
     ckan_ini_filepath = os.path.abspath(config['__file__'])
-    celery.send_task('archiver.update_package',
-                     args=[ckan_ini_filepath, package.id, queue],
-                     task_id=task_id, queue=queue)
+
+    compat_enqueue('archiver.update_package', update_package, [ckan_ini_filepath, package.id, queue])
+
+    #celery.send_task('archiver.update_package',
+    #                 args=[ckan_ini_filepath, package.id, queue],
+    #                 task_id=task_id, queue=queue)
     log.debug('Archival of package put into celery queue %s: %s',
               queue, package.name)
 

--- a/ckanext/archiver/lib.py
+++ b/ckanext/archiver/lib.py
@@ -3,7 +3,6 @@ import logging
 import ckan.plugins as p
 
 from ckan.model.types import make_uuid
-from ckan.lib.celery_app import celery
 
 from ckanext.archiver.tasks import update_package, update_resource
 

--- a/ckanext/archiver/lib.py
+++ b/ckanext/archiver/lib.py
@@ -36,9 +36,7 @@ def create_archiver_resource_task(resource, queue):
     ckan_ini_filepath = os.path.abspath(config['__file__'])
 
     compat_enqueue('archiver.update_resource', queue, [ckan_ini_filepath, resource.id])
-    #celery.send_task('archiver.update_resource',
-    #                 args=[ckan_ini_filepath, resource.id, queue],
-    #                 task_id=task_id, queue=queue)
+
     log.debug('Archival of resource put into celery queue %s: %s/%s url=%r',
               queue, package.name, resource.id, resource.url)
 
@@ -50,9 +48,6 @@ def create_archiver_package_task(package, queue):
 
     compat_enqueue('archiver.update_package', update_package, queue, [ckan_ini_filepath, package.id])
 
-    #celery.send_task('archiver.update_package',
-    #                 args=[ckan_ini_filepath, package.id, queue],
-    #                 task_id=task_id, queue=queue)
     log.debug('Archival of package put into celery queue %s: %s',
               queue, package.name)
 

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -22,6 +22,7 @@ from ckan.lib.celery_app import celery
 from ckan.lib import uploader
 from ckan import plugins as p
 from ckanext.archiver import interfaces as archiver_interfaces
+import ckan.lib.jobs as jobs
 
 import logging
 
@@ -32,6 +33,9 @@ toolkit = p.toolkit
 ALLOWED_SCHEMES = set(('http', 'https', 'ftp'))
 
 USER_AGENT = 'ckanext-archiver'
+
+
+
 
 
 def load_config(ckan_ini_filepath):
@@ -108,6 +112,9 @@ class CkanError(ArchiverError):
 
 
 @celery.task(name="archiver.update_resource")
+def update_resouce_celery(*args, **kwargs):
+    update_resource(*args, **kwargs)
+
 def update_resource(ckan_ini_filepath, resource_id, queue='bulk'):
     '''
     Archive a resource.
@@ -134,6 +141,9 @@ def update_resource(ckan_ini_filepath, resource_id, queue='bulk'):
         raise
 
 @celery.task(name="archiver.update_package")
+def update_package_celery(*args, **kwargs):
+    update_package(*args, **kwargs)
+
 def update_package(ckan_ini_filepath, package_id, queue='bulk'):
     '''
     Archive a package.
@@ -902,6 +912,9 @@ def response_is_an_api_error(response_body):
 
 
 @celery.task(name="archiver.clean")
+def clean_celery(*args, **kwargs):
+    clean(*args, **kwargs)
+
 def clean():
     """
     Remove all archived resources.
@@ -910,6 +923,9 @@ def clean():
 
 
 @celery.task(name="archiver.link_checker")
+def link_checker_celery(*args, **kwargs):
+    link_checker(*args, **kwargs)
+
 def link_checker(context, data):
     """
     Check that the resource's url is valid, and accepts a HEAD request.

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -34,9 +34,6 @@ ALLOWED_SCHEMES = set(('http', 'https', 'ftp'))
 USER_AGENT = 'ckanext-archiver'
 
 
-
-
-
 def load_config(ckan_ini_filepath):
     import paste.deploy
     config_abs_path = os.path.abspath(ckan_ini_filepath)

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -32,8 +32,8 @@ ALLOWED_SCHEMES = set(('http', 'https', 'ftp'))
 
 USER_AGENT = 'ckanext-archiver'
 
-# CKAN 2.8 does not have celery anymor
-if p.toolkit.check_ckan_version(max_version='2.7.99'):
+# CKAN 2.7 introduces new jobs system
+if p.toolkit.check_ckan_version(max_version='2.6.99'):
     from ckan.lib.celery_app import celery
 
     @celery.task(name="archiver.update_resource")

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -22,7 +22,6 @@ from ckan.lib.celery_app import celery
 from ckan.lib import uploader
 from ckan import plugins as p
 from ckanext.archiver import interfaces as archiver_interfaces
-import ckan.lib.jobs as jobs
 
 import logging
 

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -18,7 +18,6 @@ import urlparse
 from requests.packages import urllib3
 
 from ckan.common import _
-from ckan.lib.celery_app import celery
 from ckan.lib import uploader
 from ckan import plugins as p
 from ckanext.archiver import interfaces as archiver_interfaces
@@ -33,6 +32,25 @@ ALLOWED_SCHEMES = set(('http', 'https', 'ftp'))
 
 USER_AGENT = 'ckanext-archiver'
 
+# CKAN 2.8 does not have celery anymor
+if p.toolkit.check_ckan_version(max_version='2.7.99'):
+    from ckan.lib.celery_app import celery
+
+    @celery.task(name="archiver.update_resource")
+    def update_resouce_celery(*args, **kwargs):
+        update_resource(*args, **kwargs)
+
+    @celery.task(name="archiver.update_package")
+    def update_package_celery(*args, **kwargs):
+        update_package(*args, **kwargs)
+
+    @celery.task(name="archiver.clean")
+    def clean_celery(*args, **kwargs):
+        clean(*args, **kwargs)
+
+    @celery.task(name="archiver.link_checker")
+    def link_checker_celery(*args, **kwargs):
+        link_checker(*args, **kwargs)
 
 def load_config(ckan_ini_filepath):
     import paste.deploy
@@ -107,9 +125,6 @@ class CkanError(ArchiverError):
     pass
 
 
-@celery.task(name="archiver.update_resource")
-def update_resouce_celery(*args, **kwargs):
-    update_resource(*args, **kwargs)
 
 def update_resource(ckan_ini_filepath, resource_id, queue='bulk'):
     '''
@@ -136,9 +151,7 @@ def update_resource(ckan_ini_filepath, resource_id, queue='bulk'):
                   e, resource_id)
         raise
 
-@celery.task(name="archiver.update_package")
-def update_package_celery(*args, **kwargs):
-    update_package(*args, **kwargs)
+
 
 def update_package(ckan_ini_filepath, package_id, queue='bulk'):
     '''
@@ -906,21 +919,12 @@ def response_is_an_api_error(response_body):
     if '<ows:ExceptionReport' in response_sample:
         return True
 
-
-@celery.task(name="archiver.clean")
-def clean_celery(*args, **kwargs):
-    clean(*args, **kwargs)
-
 def clean():
     """
     Remove all archived resources.
     """
     log.error("clean task not implemented yet")
 
-
-@celery.task(name="archiver.link_checker")
-def link_checker_celery(*args, **kwargs):
-    link_checker(*args, **kwargs)
 
 def link_checker(context, data):
     """


### PR DESCRIPTION
This PR migrates celery task to new jobs system with backwards compatibility for celery. Installing archiver still installs celery too, but that is not an issue with CKAN 2.8. 