### PR TITLE
Use interface to get resource uploader

### DIFF
--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -262,13 +262,14 @@ def _update_resource(ckan_ini_filepath, resource_id, queue, log):
     if not url.startswith('http'):
         url = config['ckan.site_url'].rstrip('/') + url
 
-    hosted_externally = not url.startswith(config['ckan.site_url'])
+
+    upload = uploader.get_resource_uploader(resource)
+    filepath = upload.get_path(resource['id'])
+
+    hosted_externally = not url.startswith(config['ckan.site_url']) or urlparse.urlparse(filepath).scheme is not ''
     # if resource.get('resource_type') == 'file.upload' and not hosted_externally:
     if resource.get('url_type') == 'upload' and not hosted_externally:
         log.info("Won't attemp to archive resource uploaded locally: %s" % resource['url'])
-
-        upload = uploader.ResourceUpload(resource)
-        filepath = upload.get_path(resource['id'])
 
         try:
             hash, length = _file_hashnlength(filepath)


### PR DESCRIPTION
If archiver is used in combination with some other extension that implements its custom uploader, for example https://github.com/TkTech/ckanext-cloudstorage, archiver always uses default ckan uploader. 

This PR fixes it to use get_resource_uploader which return uploaders implemented in extensions. 

This also adds a check if get-path returns external URL.