### PR TITLE
[readme][xs]: Update supported CKAN version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Demo:
 .. image:: archiver_report.png
     :alt: Broken link report
 
-Compatibility: Requires CKAN version 2.1 or later
+Compatibility: Requires CKAN version 2.6 or later
 
 TODO:
 


### PR DESCRIPTION
Just a very small change to the supported CKAN versions in the README, base on e0c829515e0225f00436fb35ffa3803d0b8aa7fe, which says <2.6 isn't supported anymore.