### PR TITLE
do not import future in python 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/ckanext/archiver/command_celery.py
+++ b/ckanext/archiver/command_celery.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from future import standard_library
 import sys
 import os
 
@@ -9,7 +8,9 @@ from celery import Celery
 
 from ckan.lib.cli import CkanCommand
 
-standard_library.install_aliases()  # noqa
+if sys.version_info.major < 3:
+    from future import standard_library
+    standard_library.install_aliases()  # noqa
 
 
 class CeleryCmd(CkanCommand):

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from builtins import str
 import os
+import sys
 import hashlib
 import http.client
 import requests
@@ -14,7 +15,11 @@ import re
 from time import sleep
 
 from requests.packages import urllib3
-from future.moves.urllib.parse import urlparse, urljoin, quote, urlunparse
+
+if sys.version_info.major < 3:
+    from future.moves.urllib.parse import urlparse, urljoin, quote, urlunparse
+else:
+    from urllib.parse import urlparse, urljoin, quote, urlunparse
 
 from ckan.common import _
 from ckan.lib import uploader

--- a/ckanext/archiver/tests/mock_remote_server.py
+++ b/ckanext/archiver/tests/mock_remote_server.py
@@ -9,10 +9,15 @@ from contextlib import contextmanager
 from threading import Thread
 from time import sleep
 from wsgiref.simple_server import make_server
-from future.moves.urllib.request import urlopen
 import socket
 import os
+import sys
 from functools import reduce
+
+if sys.version_info.major < 3:
+    from future.moves.urllib.request import urlopen
+else:
+    from urllib.request import urlopen
 
 
 class MockHTTPServer(object):

--- a/ckanext/archiver/tests/test_archiver.py
+++ b/ckanext/archiver/tests/test_archiver.py
@@ -4,11 +4,15 @@ import os
 import shutil
 import tempfile
 import json
-
-from future.moves.urllib.parse import quote_plus
-from ckan.plugins.toolkit import config
+import sys
 import pytest
 
+if sys.version_info.major < 3:
+    from future.moves.urllib.parse import quote_plus
+else:
+    from urllib.parse import quote_plus
+
+from ckan.plugins.toolkit import config
 from ckan import model
 from ckan import plugins
 from ckan.logic import get_action


### PR DESCRIPTION
This change makes it possible to remove `future` dependency from python 3 environment. 