### PR TITLE
No need to decode a string to ASCII explicitly

### DIFF
--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -650,16 +650,6 @@ def tidy_url(url):
     It may raise LinkInvalidError if the URL has a problem.
     '''
 
-    # Find out if it has unicode characters, and if it does, quote them
-    # so we are left with an ascii string
-    try:
-        url = url.decode('ascii')
-    except Exception:
-        parts = list(urlparse(url))
-        parts[2] = quote(parts[2].encode('utf-8'))
-        url = urlunparse(parts)
-    url = str(url)
-
     # strip whitespace from url
     # (browsers appear to do this)
     url = url.strip()


### PR DESCRIPTION
Python 3 natively supports Unicode characters in strings and URLs. So, the try block can safely be removed and should be removed in py3 envs to prevent double encoding. If py2 should still be supported, let me know.

Fixes #91 