### PR TITLE
Remove future and drop 2.9 from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ckan/ckan-dev:${{ matrix.ckan-version }}
+      options: --user root
     services:
       solr:
         image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["2.11", "2.10", 2.9]
+        ckan-version: ["2.11", "2.10"]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/ckanext/archiver/command_celery.py
+++ b/ckanext/archiver/command_celery.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from future import standard_library
 import sys
 import os
 

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 import os
 import hashlib
@@ -14,7 +13,7 @@ import re
 from time import sleep
 
 from requests.packages import urllib3
-from future.moves.urllib.parse import urlparse, urljoin, quote, urlunparse
+from urllib.parse import urlparse, urljoin, quote, urlunparse
 
 from ckan.common import _
 from ckan.lib import uploader

--- a/ckanext/archiver/tests/mock_remote_server.py
+++ b/ckanext/archiver/tests/mock_remote_server.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from threading import Thread
 from time import sleep
 from wsgiref.simple_server import make_server
-from future.moves.urllib.request import urlopen
+from urllib.request import urlopen
 import socket
 import os
 from functools import reduce

--- a/ckanext/archiver/tests/test_archiver.py
+++ b/ckanext/archiver/tests/test_archiver.py
@@ -1,11 +1,10 @@
-from __future__ import print_function
 import logging
 import os
 import shutil
 import tempfile
 import json
 
-from future.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 from ckan.plugins.toolkit import config
 import pytest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 progressbar2==3.53.3
-future
 
 -e git+https://github.com/ckan/ckanext-report.git@master#egg=ckanext-report


### PR DESCRIPTION
Removes future since it's not really recommended in ckan and python2 support is not relevant anymore.